### PR TITLE
Updated ePortfolio links and added new package reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # DotNetProjectStartup
 This project demonstrates one possible way to setup and organize your Visual Studio project. As this project progresses it will be broken apart into various layers that can be consumed by one of the example project applications provided.
 
+## ePortfolio
+You can find my ePortfolio [here](https://github.com/MCLifeLeader/ePortfolio).
+
 # Project Structure
 The project is broken apart into the following examples:
 - Api.Startup.Example - This sample application is provided as a demonstration for creating a RESTful API using ASP.NET Core.

--- a/src/Api/Api.Startup.Example/RegisterDependentServices.cs
+++ b/src/Api/Api.Startup.Example/RegisterDependentServices.cs
@@ -344,8 +344,9 @@ public static class RegisterDependentServices
             {
                 Title = $"{_swaggerName} {version}",
                 Version = $"{version}",
-                Description = $"API Swagger Documentation, &copy; 2022 - {DateTime.UtcNow:yyyy} - {_swaggerName} - " +
-                              $"Build Version: {GetType().Assembly.GetName().Version}"
+                Description = $"API Swagger Documentation, &copy; 2022 - {DateTime.UtcNow:yyyy} - {_swaggerName} " +
+                              $"- <a class=\"fw-bold\" href=\"https://github.com/MCLifeLeader/ePortfolio\" target=\"_blank\" rel=\"noopener\">ePortfolio</a> " +
+                              $"- Build Version: {GetType().Assembly.GetName().Version}"
             };
         }
     }

--- a/src/Blazor/Blazor.Server.Startup.Example/Components/Pages/Home.razor
+++ b/src/Blazor/Blazor.Server.Startup.Example/Components/Pages/Home.razor
@@ -5,3 +5,5 @@
 <h1>Hello, world!</h1>
 
 Welcome to your new app.
+
+My ePortfolio can be found at <a class="fw-bold" href="https://github.com/MCLifeLeader/ePortfolio" target="_blank" rel="noopener">here</a>.

--- a/src/Blazor/Blazor.Server.Startup.Example/Startup.Blazor.Server.csproj
+++ b/src/Blazor/Blazor.Server.Startup.Example/Startup.Blazor.Server.csproj
@@ -67,6 +67,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/src/Web/Web.Startup.Example/Pages/Index.cshtml
+++ b/src/Web/Web.Startup.Example/Pages/Index.cshtml
@@ -12,7 +12,7 @@
 <div class="row">
     <div class="col-12 text-center">
         <h3>
-            Coming soon
+            My ePortfolio can be found at <a class="fw-bold" href="https://github.com/MCLifeLeader/ePortfolio" target="_blank" rel="noopener">here</a>.
         </h3>
     </div>
 </div>

--- a/src/Web/Web.Startup.Example/Startup.Web.csproj
+++ b/src/Web/Web.Startup.Example/Startup.Web.csproj
@@ -86,6 +86,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 


### PR DESCRIPTION
Updated various files to include a link to the author's ePortfolio. The README.md, `RegisterDependentServices.cs`, `Home.razor`, and `Index.cshtml` files now contain this link. The `Index.cshtml` file specifically had the "Coming soon" text replaced with the ePortfolio link. Additionally, the `Startup.Blazor.Server.csproj` and `Startup.Web.csproj` files have been updated to include a new package reference to `Microsoft.Web.LibraryManager.Build` version `2.1.175`.