### PR TITLE
Add LibraryManager package and wwwroot\lib\ item group

### DIFF
--- a/src/Aspire/Startup.Aspire/Startup.Aspire.Web/Startup.Aspire.Web.csproj
+++ b/src/Aspire/Startup.Aspire/Startup.Aspire.Web/Startup.Aspire.Web.csproj
@@ -13,6 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Seq" Version="9.0.0" />
     <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\lib\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add LibraryManager package and wwwroot\lib\ item group

Added a new package reference for `Microsoft.Web.LibraryManager.Build` version `2.1.175` in `Startup.Aspire.Web.csproj`. Also, included a new item group to add the folder path `wwwroot\lib\`.